### PR TITLE
Fix regression bug for bootloader mode introduced in 7d512c6e5c7953c3…

### DIFF
--- a/pic32.h
+++ b/pic32.h
@@ -26,6 +26,7 @@ extern const unsigned pic32_pemm_gpl[];
 extern const unsigned pic32_pemm_gpm[];
 extern const unsigned pic32_pemk[];
 
+#define FAMILY_BOOTLOADER	-1
 #define FAMILY_MX1	0
 #define FAMILY_MX3	1
 #define FAMILY_MZ	2

--- a/target.c
+++ b/target.c
@@ -60,7 +60,7 @@ family_t family_mk  = { "mk", FAMILY_MK,
  * We don't really care at the end of the day.
  */
 static const
-family_t family_bl  = { "bootloader",
+family_t family_bl  = { "bootloader", FAMILY_BOOTLOADER,
                         80, 0,      1024, 0,         0,           0,    0      };
 
 /*


### PR DESCRIPTION
…01a0bfe6d5a6a168be433555

(Error was that a struct was expanded, but bootloder's struct wasn't updated, making the initial variables be at wrong offsets/places)